### PR TITLE
Fix #3 add vars_file, message_file and fail_on_error params

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ All optional values below, if specified in the source, will act as a default val
 
 * `fail_on_error`: *Optional*. If true, the resource will fail if the Cycloid event API return an error. Default false (True values are y, yes, t, true, on and 1; false values are n, no, f, false, off and 0).
 
+* `vars_file`: *Optional*. Load vars from a file that you can use in event message or title. format `MYKEY: value` usage `my title containing vars $MYKEY`.
+
 * `tags`: *Optional*. The tags allow filtering
     Example:
     ```
@@ -88,6 +90,8 @@ Send the event to Cycloid API with the desired parameters.
 * `message`: *Optional*. The message in the event body
 
 * `fail_on_error`: *Optional*. If true, the resource will fail if the Cycloid event API return an error. Default false (True values are y, yes, t, true, on and 1; false values are n, no, f, false, off and 0).
+
+* `vars_file`: *Optional*. Load vars from a file that you can use in event message or title. format `MYKEY: value` usage `my title containing vars $MYKEY`.
 
 * `tags`: *Optional*. The tags allow filtering
     Example:

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ All optional values below, if specified in the source, will act as a default val
 
 * `message`: *Optional*. The message in the event body
 
+* `fail_on_error`: *Optional*. If true, the resource will fail if the Cycloid event API return an error. Default false (True values are y, yes, t, true, on and 1; false values are n, no, f, false, off and 0).
+
 * `tags`: *Optional*. The tags allow filtering
     Example:
     ```
@@ -84,6 +86,8 @@ Send the event to Cycloid API with the desired parameters.
 * `title`: *Optional*. The title of the event
 
 * `message`: *Optional*. The message in the event body
+
+* `fail_on_error`: *Optional*. If true, the resource will fail if the Cycloid event API return an error. Default false (True values are y, yes, t, true, on and 1; false values are n, no, f, false, off and 0).
 
 * `tags`: *Optional*. The tags allow filtering
     Example:

--- a/README.md
+++ b/README.md
@@ -24,14 +24,14 @@ resource_types:
 
 All optional values below, if specified in the source, will act as a default value until it's overrided by the params configuration.
 
-* `api_url`: *Required.* The url of the Cycloid DevOps Platform API
+* `api_url`: *Required.* The url of the Cycloid DevOps Platform API.
     Example: `https://http-api.cycloid.io`
 
-* `api_login`: *Required*. The login of the account you will use to store those events
+* `api_login`: *Required*. The login of the account you will use to store those events.
 
-* `api_password`: *Required*. The password of the account declared above
+* `api_password`: *Required*. The password of the account declared above.
 
-* `organization`: *Required*. The organization where you will store the events
+* `organization`: *Required*. The organization where you will store the events.
 
 * `type`: *Optional*. The type of the event. Currently, only `Cycloid`, `Custom`, `AWS` or `Monitoring` are allowed.
 
@@ -40,17 +40,17 @@ All optional values below, if specified in the source, will act as a default val
 * `icon`: *Optional*. Icon to display. The icons are the ones from Font Awesome.
     Example: `fa-cubes`
 
-* `title`: *Optional*. The title of the event
+* `title`: *Optional*. The title of the event.
 
 * `message`: *Optional*. The message in the event body.
 
-* `message_file`: *Optional*. File path which contain the message for event body
+* `message_file`: *Optional*. File path which contain the message for event body.
 
 * `fail_on_error`: *Optional*. If true, the resource will fail if the Cycloid event API return an error. Default false (True values are y, yes, t, true, on and 1; false values are n, no, f, false, off and 0).
 
 * `vars_file`: *Optional*. Load vars from a file that you can use in event message or title. format `MYKEY: value` usage `my title containing vars $MYKEY`.
 
-* `tags`: *Optional*. The tags allow filtering
+* `tags`: *Optional*. The tags allow filtering.
     Example:
     ```
     tags:
@@ -87,17 +87,17 @@ Send the event to Cycloid API with the desired parameters.
 * `icon`: *Required*. Icon to display. The icons are the ones from Font Awesome.
     Example: `fa-cubes`
 
-* `title`: *Required*. The title of the event
+* `title`: *Required*. The title of the event.
 
-* `message`: *Optional*. The message in the event body. (required `message` or `message_file` to be defined)
+* `message`: *Optional*. The message in the event body. (required `message` or `message_file` to be defined).
 
-* `message_file`: *Optional*. File path which contain the message for event body
+* `message_file`: *Optional*. File path which contain the message for event body.
 
 * `fail_on_error`: *Optional*. If true, the resource will fail if the Cycloid event API return an error. Default false (True values are y, yes, t, true, on and 1; false values are n, no, f, false, off and 0).
 
 * `vars_file`: *Optional*. Load vars from a file that you can use in event message or title. format `MYKEY: value` usage `my title containing vars $MYKEY`.
 
-* `tags`: *Required*. The tags allow filtering
+* `tags`: *Required*. The tags allow filtering.
     Example:
     ```
     tags:

--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ All optional values below, if specified in the source, will act as a default val
 
 * `title`: *Optional*. The title of the event
 
-* `message`: *Optional*. The message in the event body
+* `message`: *Optional*. The message in the event body.
+
+* `message_file`: *Optional*. File path which contain the message for event body
 
 * `fail_on_error`: *Optional*. If true, the resource will fail if the Cycloid event API return an error. Default false (True values are y, yes, t, true, on and 1; false values are n, no, f, false, off and 0).
 
@@ -75,25 +77,27 @@ Send the event to Cycloid API with the desired parameters.
 #### Parameters
 
  ```
- /!\ Those parameters are *Required* if they aren't defined yet in the Source configuration /!\
+ /!\ *Required* parameters can be defined here or in the Source configuration /!\
  ```
 
-* `type`: *Optional*. The type of the event. Currently, only `Cycloid`, `Custom`, `AWS` or `Monitoring` are allowed.
+* `type`: *Required*. The type of the event. Currently, only `Cycloid`, `Custom`, `AWS` or `Monitoring` are allowed.
 
-* `severity`: *Optional*. The severity of the event. Currently, only `info`, `warn`, `err` or `crit` are allowed.
+* `severity`: *Required*. The severity of the event. Currently, only `info`, `warn`, `err` or `crit` are allowed.
 
-* `icon`: *Optional*. Icon to display. The icons are the ones from Font Awesome.
+* `icon`: *Required*. Icon to display. The icons are the ones from Font Awesome.
     Example: `fa-cubes`
 
-* `title`: *Optional*. The title of the event
+* `title`: *Required*. The title of the event
 
-* `message`: *Optional*. The message in the event body
+* `message`: *Optional*. The message in the event body. (required `message` or `message_file` to be defined)
+
+* `message_file`: *Optional*. File path which contain the message for event body
 
 * `fail_on_error`: *Optional*. If true, the resource will fail if the Cycloid event API return an error. Default false (True values are y, yes, t, true, on and 1; false values are n, no, f, false, off and 0).
 
 * `vars_file`: *Optional*. Load vars from a file that you can use in event message or title. format `MYKEY: value` usage `my title containing vars $MYKEY`.
 
-* `tags`: *Optional*. The tags allow filtering
+* `tags`: *Required*. The tags allow filtering
     Example:
     ```
     tags:

--- a/assets/events.py
+++ b/assets/events.py
@@ -32,6 +32,7 @@ class EventsResource:
         self.icon = None
         self.message = None
         self.vars_file = None
+        self.message_file = None
         self.fail_on_error = False
         self.severity = None
         self.tags = None
@@ -130,13 +131,20 @@ class EventsResource:
 
         merge = self._merge_source_params(source, params)
         self._check_params('icon', merge)
-        self._check_params('message', merge)
+        self._check_params('message', merge, False)
+        self._check_params('message_file', merge, False)
         self._check_params('severity', merge)
         self._check_params('title', merge)
         self._check_params('type', merge)
         self._check_params('tags', merge)
         self._check_params('fail_on_error', merge, default=False)
         self._check_params('vars_file', merge, default=None)
+
+        if not self.message and not self.message_file:
+            log.error("message or message_file params have to be defined")
+            exit(1)
+        elif not self.message and self.message_file:
+            self._load_message_from_file()
 
         if self.vars_file is not None:
             self._load_vars_file()
@@ -154,6 +162,15 @@ class EventsResource:
             'version': {'timestamp': '0'},
             'metadata': metadata,
         }
+
+    def _load_message_from_file(self):
+        log.debug("Loading message from file %s" % self.message_file)
+        try:
+            with open(self.message_file, "r") as f:
+                self.message = f.read()
+        except Exception as e:
+            log.error("Unable to read message from file %s : %s" % (self.message_file, e))
+            exit(1)
 
     def _load_vars_file(self):
         log.debug("Loading vars from %s" % self.vars_file)

--- a/assets/events.py
+++ b/assets/events.py
@@ -5,6 +5,7 @@ import requests
 import logging as log
 import os
 from os.path import expandvars
+from os.path import join as pjoin
 import sys
 import yaml
 from distutils.util import strtobool
@@ -144,10 +145,10 @@ class EventsResource:
             log.error("message or message_file params have to be defined")
             exit(1)
         elif not self.message and self.message_file:
-            self._load_message_from_file()
+            self._load_message_from_file(target_dir)
 
         if self.vars_file is not None:
-            self._load_vars_file()
+            self._load_vars_file(target_dir)
 
         log.debug('environment: %s', os.environ)
         self._send_events()
@@ -163,19 +164,19 @@ class EventsResource:
             'metadata': metadata,
         }
 
-    def _load_message_from_file(self):
+    def _load_message_from_file(self, target_dir):
         log.debug("Loading message from file %s" % self.message_file)
         try:
-            with open(self.message_file, "r") as f:
+            with open(pjoin(target_dir, self.message_file), "r") as f:
                 self.message = f.read()
         except Exception as e:
             log.error("Unable to read message from file %s : %s" % (self.message_file, e))
             exit(1)
 
-    def _load_vars_file(self):
+    def _load_vars_file(self, target_dir):
         log.debug("Loading vars from %s" % self.vars_file)
         try:
-            with open(self.vars_file, "r") as f:
+            with open(pjoin(target_dir, self.vars_file), "r") as f:
                 variables = yaml.load(f)
         except Exception as e:
             log.error("Unable to load vars from file %s : %s" % (self.vars_file, e))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 simplejson
 requests
+pyyaml


### PR DESCRIPTION
Add 3 new params

  * `message`: *Optional*. The message in the event body.
  * `message_file`: *Optional*. File path which contain the message for event body
   * `fail_on_error`: *Optional*. If true, the resource will fail if the Cycloid event API return an error. Default false (True values are y, yes, t, true, on and 1; false values are n, no, f, false, off and 0).
