### PR TITLE
Sync with our new event API version returning 200 HTTP code

### DIFF
--- a/assets/events.py
+++ b/assets/events.py
@@ -226,7 +226,7 @@ class EventsResource:
 
         r = requests.post('%s/organizations/%s/events' % (self.api_url, self.organization), data=json.dumps(payload), headers=headers)
         log.debug(r.text)
-        if r.status_code != 201:
+        if r.status_code != 200:
             self._panic("Unable to send event : %s" % r.text)
 
 


### PR DESCRIPTION
Our last release of Cycloid API return a HTTP 200 instead of a 201.